### PR TITLE
Fix tmessagesproj compilation errors

### DIFF
--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoChatSettingsActivity.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoChatSettingsActivity.java
@@ -53,6 +53,7 @@ import org.telegram.ui.Components.UndoView;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import kotlin.Unit;
@@ -330,7 +331,7 @@ public class NekoChatSettingsActivity extends BaseNekoXSettingsActivity implemen
     // Extra Settings
     private final AbstractConfigCell headerExtraSettings = cellGroup.appendCell(new ConfigCellHeader(getString(R.string.ExtraSettings)));
     private final AbstractConfigCell hiddenChatEnabledRow = cellGroup.appendCell(new ConfigCellTextCheck(NekoConfig.hiddenChatEnabled, getString(R.string.HiddenChatDescription)));
-    private final AbstractConfigCell hiddenChatPinRow = cellGroup.appendCell(new ConfigCellTextInput(null, NekoConfig.hiddenChatPin, LocaleController.getString(R.string.HiddenChatPinHint), null, input -> input.length() == 4 && input.matches("\\d+") ? input : null));
+    private final AbstractConfigCell hiddenChatPinRow = cellGroup.appendCell(new ConfigCellTextInput(null, NekoConfig.hiddenChatPin, LocaleController.getString(R.string.HiddenChatPinHint), null, (Function<String, String>) input -> input.length() == 4 && input.matches("\\d+") ? input : null));
     private final AbstractConfigCell hiddenChatAutoExitTimeRow = cellGroup.appendCell(new ConfigCellCustom("HiddenChatAutoExitTime", CellGroup.ITEM_TYPE_TEXT_SETTINGS_CELL, true));
     private final AbstractConfigCell dividerExtraSettings = cellGroup.appendCell(new ConfigCellDivider());
 


### PR DESCRIPTION
Fixes compilation error in `NekoChatSettingsActivity` by adding explicit type casting for a lambda and importing `java.util.function.Function`.

The `ConfigCellTextInput` constructor call was failing with an "incompatible types" error due to the compiler's inability to correctly infer the type of the lambda expression. Explicitly casting the lambda to `Function<String, String>` resolved this type inference ambiguity.

---
<a href="https://cursor.com/background-agent?bcId=bc-1a67740d-d6cb-44a7-93d5-b170f639ebaa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1a67740d-d6cb-44a7-93d5-b170f639ebaa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>